### PR TITLE
Feature/mediawiki

### DIFF
--- a/mediawiki-pdf-renderer/Dockerfile
+++ b/mediawiki-pdf-renderer/Dockerfile
@@ -19,4 +19,6 @@ RUN pip install \
     mwlib==0.15.14 \
     mwlib.rl==0.14.5
 
+EXPOSE 8899
+
 CMD ["/bin/bash", "-c", "nserve & nslave --cachedir ~/cache/ & postman & mw-qserve"]

--- a/mediawiki-pdf-renderer/Dockerfile
+++ b/mediawiki-pdf-renderer/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:8
+
+RUN apt-get update && apt-get install -y \
+    g++ \
+    perl \
+    python \
+    python-dev \
+    python-setuptools \
+    python-imaging \
+    python-lxml \
+    libevent-dev \
+    openssl \
+    ca-certificates
+
+RUN easy_install pip
+
+RUN pip install \
+    gevent==1.1.2 \
+    mwlib==0.15.14 \
+    mwlib.rl==0.14.5
+
+CMD ["/bin/bash", "-c", "nserve & nslave --cachedir ~/cache/ & postman & mw-qserve"]

--- a/mediawiki/CustomSettings.php
+++ b/mediawiki/CustomSettings.php
@@ -47,9 +47,9 @@ $wgMathFullRestbaseURL='https://api.formulasearchengine.com/';
 
 require_once "$IP/extensions/OpenID/OpenID.php";
 
-$wgOpenIDLoginOnly=true;
-$wgOpenIDMode='consumer';
-$wgOpenIDTrustEmailAddress=true;
+$wgOpenIDLoginOnly = true;
+$wgOpenIDMode = 'consumer';
+$wgOpenIDTrustEmailAddress = true;
 $wgOpenIDForcedProvider = 'https://stepik.org/openid/xrds/';
 $wgOpenIDAllowExistingAccountSelection = false;
 $wgOpenIDAllowAutomaticUsername = false;
@@ -59,3 +59,10 @@ require_once "$IP/extensions/DeleteBatch/DeleteBatch.php";
 
 $wgGroupPermissions['bureaucrat']['deletebatch'] = false;
 $wgGroupPermissions['sysop']['deletebatch'] = true;
+
+require_once "$IP/extensions/Collection/Collection.php";
+
+$wgCollectionMWServeURL = $_ENV("MEDIAWIKI_PDF_RENDERER_URL");
+
+$wgGroupPermissions['user']['collectionsaveascommunitypage'] = true;
+$wgGroupPermissions['user']['collectionsaveasuserpage'] = true;

--- a/mediawiki/CustomSettings.php
+++ b/mediawiki/CustomSettings.php
@@ -1,5 +1,8 @@
 <?php
 
+$wgLogo = "https://stepik.org/static/classic/ico/favicon_128.png";
+$wgFavicon = "https://stepik.org/static/classic/ico/favicon.ico";
+
 $wgGroupPermissions['*']['edit'] = false;
 $wgGroupPermissions['*']['createpage'] = false;
 $wgGroupPermissions['*']['createtalk'] = false;

--- a/mediawiki/CustomSettings.php
+++ b/mediawiki/CustomSettings.php
@@ -62,7 +62,7 @@ $wgGroupPermissions['sysop']['deletebatch'] = true;
 
 require_once "$IP/extensions/Collection/Collection.php";
 
-$wgCollectionMWServeURL = $_ENV("MEDIAWIKI_PDF_RENDERER_URL");
+$wgCollectionMWServeURL = getenv('MEDIAWIKI_PDF_RENDERER_URL');
 
 $wgGroupPermissions['user']['collectionsaveascommunitypage'] = true;
 $wgGroupPermissions['user']['collectionsaveasuserpage'] = true;

--- a/mediawiki/CustomSettings.php
+++ b/mediawiki/CustomSettings.php
@@ -16,6 +16,7 @@ $wgGroupPermissions['sysop']['createtalk'] = true;
 $wgGroupPermissions['sysop']['move'] = true;
 
 $wgAllowImageTag = true;
+$wgEnableUploads = true;
 
 $wgJobRunRate = 1000;
 $wgRunJobsAsync = false;

--- a/mediawiki/CustomSettings.php
+++ b/mediawiki/CustomSettings.php
@@ -43,7 +43,7 @@ $wgMathFullRestbaseURL='https://api.formulasearchengine.com/';
 
 require_once "$IP/extensions/OpenID/OpenID.php";
 
-$wgOpenIDLoginOnly=false;
+$wgOpenIDLoginOnly=true;
 $wgOpenIDMode='consumer';
 $wgOpenIDTrustEmailAddress=true;
 $wgOpenIDForcedProvider = 'https://stepik.org/openid/xrds/';

--- a/mediawiki/CustomSettings.php
+++ b/mediawiki/CustomSettings.php
@@ -1,0 +1,57 @@
+<?php
+
+$wgGroupPermissions['*']['edit'] = false;
+$wgGroupPermissions['*']['createpage'] = false;
+$wgGroupPermissions['*']['createtalk'] = false;
+$wgGroupPermissions['*']['move'] = false;
+
+$wgGroupPermissions['user']['edit'] = true;
+$wgGroupPermissions['user']['createpage'] = true;
+$wgGroupPermissions['user']['createtalk'] = true;
+$wgGroupPermissions['user']['move'] = false;
+
+$wgGroupPermissions['sysop']['edit'] = true;
+$wgGroupPermissions['sysop']['createpage'] = true;
+$wgGroupPermissions['sysop']['createtalk'] = true;
+$wgGroupPermissions['sysop']['move'] = true;
+
+$wgAllowImageTag = true;
+
+$wgJobRunRate = 1000;
+$wgRunJobsAsync = false;
+
+## Extensions
+wfLoadExtension( 'WikiEditor' );
+
+$wgDefaultUserOptions['usebetatoolbar'] = 1;
+$wgDefaultUserOptions['usebetatoolbar-cgd'] = 1;
+$wgDefaultUserOptions['wikieditor-preview'] = 1;
+$wgDefaultUserOptions['wikieditor-publish'] = 1;
+
+wfLoadExtension( 'CategoryTree' );
+
+$wgCategoryTreeDefaultOptions['mode'] = 'pages';
+$wgCategoryTreeMaxDepth = array(CT_MODE_PAGES => 3, CT_MODE_ALL => 3, CT_MODE_CATEGORIES => 3);
+$wgCategoryTreeDefaultOptions['depth'] = 3;
+$wgCategoryTreeDefaultMode = CT_MODE_PAGES;
+$wgCategoryTreeDisableCache = 10;
+
+wfLoadExtension( 'Math' );
+
+$wgDefaultUserOptions['math'] = 'mathml';
+$wgMathFullRestbaseURL='https://api.formulasearchengine.com/';
+
+require_once "$IP/extensions/OpenID/OpenID.php";
+
+$wgOpenIDLoginOnly=false;
+$wgOpenIDMode='consumer';
+$wgOpenIDTrustEmailAddress=true;
+$wgOpenIDForcedProvider = 'https://stepik.org/openid/xrds/';
+$wgOpenIDAllowExistingAccountSelection = false;
+$wgOpenIDAllowAutomaticUsername = false;
+$wgOpenIDSmallLogoUrl = 'https://stepik.org/static/classic/ico/favicon_16.png';
+
+require_once "$IP/extensions/DeleteBatch/DeleteBatch.php";
+
+$wgGroupPermissions['bureaucrat']['deletebatch'] = false;
+$wgGroupPermissions['sysop']['deletebatch'] = true;

--- a/mediawiki/Dockerfile
+++ b/mediawiki/Dockerfile
@@ -29,7 +29,12 @@ RUN wget https://extdist.wmflabs.org/dist/extensions/CategoryTree-REL1_28-824260
 RUN wget https://github.com/StepicOrg/mediawiki-extensions-OpenID/archive/REL1_27.tar.gz \
     && tar -xzf REL1_27.tar.gz -C /usr/src/mediawiki/extensions/ \
     && mv /usr/src/mediawiki/extensions/mediawiki-extensions-OpenID-REL1_27 /usr/src/mediawiki/extensions/OpenID \
-    && rm REL1_27.tar.gz
+    && rm REL1_27.tar.gz \
+    && wget https://github.com/openid/php-openid/archive/2.3.0.tar.gz \
+    && tar -xzf 2.3.0.tar.gz \
+    && mv php-openid-2.3.0/Auth /usr/src/mediawiki/extensions/OpenID/Auth \
+    && rm 2.3.0.tar.gz \
+    && rm -rf php-openid-2.3.0
 
 # install Math
 RUN wget https://extdist.wmflabs.org/dist/extensions/Math-REL1_27-ba08a3a.tar.gz \

--- a/mediawiki/Dockerfile
+++ b/mediawiki/Dockerfile
@@ -1,0 +1,44 @@
+FROM wikimedia/mediawiki:latest
+
+
+RUN apt-get update \
+    && apt-get install -y \
+        wget \
+        # python needs for SyntaxHighlight_GeSHi
+        python3.5 \
+    && ln -sf /usr/bin/python3.5 /usr/bin/python
+
+# install SyntaxHighlight_GeSHi
+RUN wget https://github.com/StepicOrg/mediawiki-extensions-SyntaxHighlight_GeSHi/archive/REL1_27.tar.gz \
+    && tar -xzf REL1_27.tar.gz -C /usr/src/mediawiki/extensions/ \
+    && rmdir /usr/src/mediawiki/extensions/SyntaxHighlight_GeSHi \
+    && mv /usr/src/mediawiki/extensions/mediawiki-extensions-SyntaxHighlight_GeSHi-REL1_27 /usr/src/mediawiki/extensions/SyntaxHighlight_GeSHi \
+    && rm REL1_27.tar.gz
+
+# install WikiEditor
+RUN wget https://extdist.wmflabs.org/dist/extensions/WikiEditor-REL1_27-952e04b.tar.gz \
+    && tar -xzf WikiEditor-REL1_27-952e04b.tar.gz -C /usr/src/mediawiki/extensions \
+    && rm WikiEditor-REL1_27-952e04b.tar.gz
+
+# install CategoryTree
+RUN wget https://extdist.wmflabs.org/dist/extensions/CategoryTree-REL1_28-8242603.tar.gz \
+    && tar -xzf CategoryTree-REL1_28-8242603.tar.gz -C /usr/src/mediawiki/extensions \
+    && rm CategoryTree-REL1_28-8242603.tar.gz
+
+# install OpenID
+RUN wget https://github.com/StepicOrg/mediawiki-extensions-OpenID/archive/REL1_27.tar.gz \
+    && tar -xzf REL1_27.tar.gz -C /usr/src/mediawiki/extensions/ \
+    && mv /usr/src/mediawiki/extensions/mediawiki-extensions-OpenID-REL1_27 /usr/src/mediawiki/extensions/OpenID \
+    && rm REL1_27.tar.gz
+
+# install Math
+RUN wget https://extdist.wmflabs.org/dist/extensions/Math-REL1_27-ba08a3a.tar.gz \
+    && tar -xzf Math-REL1_27-ba08a3a.tar.gz -C /usr/src/mediawiki/extensions \
+    && rm Math-REL1_27-ba08a3a.tar.gz
+
+# install DeleteBatch
+RUN wget https://extdist.wmflabs.org/dist/extensions/DeleteBatch-REL1_27-f6fe947.tar.gz \
+    && tar -xzf DeleteBatch-REL1_27-f6fe947.tar.gz -C /usr/src/mediawiki/extensions \
+    && rm DeleteBatch-REL1_27-f6fe947.tar.gz
+
+COPY CustomSettings.php /conf/

--- a/mediawiki/Dockerfile
+++ b/mediawiki/Dockerfile
@@ -46,4 +46,9 @@ RUN wget https://extdist.wmflabs.org/dist/extensions/DeleteBatch-REL1_27-f6fe947
     && tar -xzf DeleteBatch-REL1_27-f6fe947.tar.gz -C /usr/src/mediawiki/extensions \
     && rm DeleteBatch-REL1_27-f6fe947.tar.gz
 
+# install Collection
+RUN wget https://extdist.wmflabs.org/dist/extensions/Collection-REL1_27-b883366.tar.gz \
+    && tar -xzf Collection-REL1_27-b883366.tar.gz -C /usr/src/mediawiki/extensions \
+    && rm Collection-REL1_27-b883366.tar.gz
+
 COPY CustomSettings.php /conf/

--- a/teamcity-agent-deploy/Dockerfile
+++ b/teamcity-agent-deploy/Dockerfile
@@ -10,4 +10,5 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
 RUN pip install --no-cache-dir -U pip \
  && pip install --no-cache-dir ansible==$ANSIBLE_VERSION
 
+RUN mkdir -p /opt/ansible/roles && chown -R $USER:$USER /opt/ansible
 COPY ansible.cfg $HOME/.ansible.cfg

--- a/teamcity-agent-deploy/ansible.cfg
+++ b/teamcity-agent-deploy/ansible.cfg
@@ -1,4 +1,5 @@
 [defaults]
+roles_path = /opt/ansible/roles
 retry_files_enabled = False
 stdout_callback = debug
 sudo_flags = -HE


### PR DESCRIPTION
* Dockerfile для mediawiki [#EDY-7208](https://vyahhi.myjetbrains.com/youtrack/issue/EDY-7208)
* Dockerfile для mediawiki-pdf-renderer [#EDY-7235](https://vyahhi.myjetbrains.com/youtrack/issue/EDY-7235)

При запуске контейнера mediawiki нужно ему передавать (помимо тех, что уже передаются) environment variable `MEDIAWIKI_PDF_RENDERER_URL`.

Сам же `mediawiki-pdf-renderer` слушает порт 8899.

Ссылки по теме: [раз](https://www.mediawiki.org/wiki/Extension:Collection), [два](https://www.mediawiki.org/wiki/Extension:PDF_Writer)

Локально я тестил это так 
```
docker run --name mediawiki-pdf-renderer \
    -p 172.17.0.1:8899:8899 \
    -d stepik/mediawiki-pdf-renderer \
&& docker run --name mediawiki-db \
    -e MYSQL_DATABASE=mediawiki \
    -e MYSQL_ROOT_PASSWORD=mediawiki \
    -e MYSQL_USER=mediawiki \
    -e MYSQL_PASSWORD=mediawiki \
    -p 172.17.0.1:3306:3306 \
    -d mysql:5.6.35 \
&& sleep 10 \
&& docker run --name mediawiki \
    -e 'MEDIAWIKI_RESTBASE_URL=http://localhost' \
    -e 'MEDIAWIKI_DB_PASSWORD=mediawiki' \
    -e 'MEDIAWIKI_DB_HOST=172.17.0.1' \
    -e 'MEDIAWIKI_UPDATE=true' \
    -e 'MEDIAWIKI_ADMIN_USER=admin' \
    -e 'MEDIAWIKI_DB_PORT=3306' \
    -e 'MEDIAWIKI_SITE_SERVER=//172.17.0.1:8080' \
    -e 'MEDIAWIKI_ADMIN_PASS=adminpass' \
    -e 'MEDIAWIKI_DB_NAME=mediawiki' \
    -e 'MEDIAWIKI_SITE_LANG=en' \
    -e 'MEDIAWIKI_SITE_NAME=Stepik Wiki' \
    -e 'MEDIAWIKI_DB_USER=mediawiki' \
    -e 'MEDIAWIKI_RESTBASE_URL=http://localhost' \
    -e 'MEDIAWIKI_PDF_RENDERER_URL=http://172.17.0.1:8899' \
    -p 172.17.0.1:8080:80 \
    -v ~/work/dockerfiles/mediawiki/data:/data:rw stepik/mediawiki
```
